### PR TITLE
Fix behavior when reading empty files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,4 @@ dkms.conf
 *.txt
 
 src_cpp/
+src_java/

--- a/src_c/extractor.c
+++ b/src_c/extractor.c
@@ -7,7 +7,7 @@ int main(int argc, char *argv[])
     // version will not print to the terminal.
     if (argc != 3)
     {
-        printf("Usage: ./%s input_file output_file\n", argv[0]);
+        printf("Usage: %s input_file output_file\n", argv[0]);
         return 1;
     }
 

--- a/src_c/extractor.c
+++ b/src_c/extractor.c
@@ -18,14 +18,14 @@ int main(int argc, char *argv[])
     FILE *output_file = fopen(argv[2], "w");
     if (area_file == NULL)
     {
-        remove(argv[2]);
         printf("Error opening input file\n");
+        remove(argv[2]);
         return 2;
     }
     else if (output_file == NULL)
     {
-        remove(argv[2]);
         printf("Error opening output file\n");
+        remove(argv[2]);
         return 3;
     }
 
@@ -39,8 +39,8 @@ int main(int argc, char *argv[])
     node *temp = calloc(1, sizeof(node));
     if (temp == NULL)
     {
-        remove(argv[2]);
         printf("Failed to allocate memory\n");
+        remove(argv[2]);
         return 4;
     }
     chunk_chain = temp;
@@ -50,59 +50,55 @@ int main(int argc, char *argv[])
     bool final_chunk = false;
     bool first_chunk = true;
     bool paddings_found[2] = {false, false};
-    printf("somehow this returns true");
+
+    fread(chunk, 1, sizeof(chunk), area_file)
+    if (!is_math_tbl(chunk))
+    {
+        printf("Not a valid .EMI file!\n");
+        fclose(area_file);
+        fclose(output_file);
+        remove(argv[2]);
+        return 5;
+    }
+
     while (fread(chunk, 1, sizeof(chunk), area_file) > 0 && !final_chunk)
     {
-        printf("somehow this also returns true");
-        // Checks the 8th-15th byte of the first chunk
-        // for the "magic number" of an EMI file.
-        if (first_chunk && !is_math_tbl(chunk))
+        printf("should not print");
+        if (!(paddings_found[0] && paddings_found[1]))
         {
-            remove(argv[2]);
-            printf("Not a valid .EMI file!\n");
-            fclose(area_file);
-            fclose(output_file);
-            return 5;
+            // if the current chunk matches the first prepadding
+            // and the second chunk hasn't been discovered yet
+            // then this chunk is indeed the first prepadding
+            // (order matters here since there may be other
+            // chunks consisting of 512x 0x5F)
+            if (!paddings_found[1] && is_first_prepadding(chunk))
+            {
+                paddings_found[0] = true;
+            }
+            // similar with the above case but now
+            // checks if the first prepadding has been found.         
+            else if (paddings_found[0] && is_second_prepadding(chunk))
+            {
+                paddings_found[1] = true;
+            }
         }
         else
         {
-            first_chunk = false;
-            if (!(paddings_found[0] && paddings_found[1]))
+            // Needed to determine the size of the dialogue
+            // section.
+            chunk_count++;
+            temp->next = calloc(1, sizeof(node));
+            if (temp->next == NULL)
             {
-                // if the current chunk matches the first prepadding
-                // and the second chunk hasn't been discovered yet
-                // then this chunk is indeed the first prepadding
-                // (order matters here since there may be other
-                // chunks consisting of 512x 0x5F)
-                if (!paddings_found[1] && is_first_prepadding(chunk))
-                {
-                    paddings_found[0] = true;
-                }
-                // similar with the above case but now
-                // checks if the first prepadding has been found.         
-                else if (paddings_found[0] && is_second_prepadding(chunk))
-                {
-                    paddings_found[1] = true;
-                }
+                printf("Failed to allocate memory\n");
+                return 4;
             }
-            else
-            {
-                // Needed to determine the size of the dialogue
-                // section.
-                chunk_count++;
-                temp->next = calloc(1, sizeof(node));
-                if (temp->next == NULL)
-                {
-                    printf("Failed to allocate memory\n");
-                    return 4;
-                }
-                // Copy the current chunk to the current node's
-                // chunk.
-                copy_arrays(temp->chunk, chunk, 512);
-                temp = temp->next;
-                // Check if this is the final chunk.
-                final_chunk = is_final_chunk(chunk);
-            }
+            // Copy the current chunk to the current node's
+            // chunk.
+            copy_arrays(temp->chunk, chunk, 512);
+            temp = temp->next;
+            // Check if this is the final chunk.
+            final_chunk = is_final_chunk(chunk);
         }
     }
 

--- a/src_c/extractor.c
+++ b/src_c/extractor.c
@@ -51,7 +51,7 @@ int main(int argc, char *argv[])
     bool first_chunk = true;
     bool paddings_found[2] = {false, false};
 
-    fread(chunk, 1, sizeof(chunk), area_file)
+    fread(chunk, 1, sizeof(chunk), area_file);
     if (!is_math_tbl(chunk))
     {
         printf("Not a valid .EMI file!\n");

--- a/src_c/extractor.c
+++ b/src_c/extractor.c
@@ -50,9 +50,10 @@ int main(int argc, char *argv[])
     bool final_chunk = false;
     bool first_chunk = true;
     bool paddings_found[2] = {false, false};
-
+    printf("somehow this returns true");
     while (fread(chunk, 1, sizeof(chunk), area_file) > 0 && !final_chunk)
     {
+        printf("somehow this also returns true");
         // Checks the 8th-15th byte of the first chunk
         // for the "magic number" of an EMI file.
         if (first_chunk && !is_math_tbl(chunk))
@@ -65,7 +66,6 @@ int main(int argc, char *argv[])
         }
         else
         {
-            printf("somehow this returns true");
             first_chunk = false;
             if (!(paddings_found[0] && paddings_found[1]))
             {

--- a/src_c/extractor.c
+++ b/src_c/extractor.c
@@ -18,11 +18,13 @@ int main(int argc, char *argv[])
     FILE *output_file = fopen(argv[2], "w");
     if (area_file == NULL)
     {
+        remove(argv[2]);
         printf("Error opening input file\n");
         return 2;
     }
     else if (output_file == NULL)
     {
+        remove(argv[2]);
         printf("Error opening output file\n");
         return 3;
     }
@@ -37,6 +39,7 @@ int main(int argc, char *argv[])
     node *temp = calloc(1, sizeof(node));
     if (temp == NULL)
     {
+        remove(argv[2]);
         printf("Failed to allocate memory\n");
         return 4;
     }
@@ -54,6 +57,7 @@ int main(int argc, char *argv[])
         // for the "magic number" of an EMI file.
         if (first_chunk && !is_math_tbl(chunk))
         {
+            remove(argv[2]);
             printf("Not a valid .EMI file!\n");
             fclose(area_file);
             fclose(output_file);
@@ -61,6 +65,7 @@ int main(int argc, char *argv[])
         }
         else
         {
+            printf("somehow this returns true");
             first_chunk = false;
             if (!(paddings_found[0] && paddings_found[1]))
             {
@@ -105,6 +110,7 @@ int main(int argc, char *argv[])
     // the dialogue section.
     if (!(paddings_found[0] && paddings_found[1]))
     {
+        remove(argv[2]);
         printf("No dialogue section found in this .EMI file!\n");
         return 6;
     }

--- a/src_c/utils.c
+++ b/src_c/utils.c
@@ -29,6 +29,7 @@ bool is_math_tbl(byte chunk[])
             return false;
         }
     }
+    printf("somehow this returns true");
     return true;
 }
 

--- a/src_c/utils.c
+++ b/src_c/utils.c
@@ -29,7 +29,6 @@ bool is_math_tbl(byte chunk[])
             return false;
         }
     }
-    printf("somehow this returns true");
     return true;
 }
 


### PR DESCRIPTION
Behavior before:
- Opening empty files would return a code 6 error, instead of the more appropriate code 5 error

Behavior now:
- Opening empty files returns a code 5 error, as empty files are invalid files.